### PR TITLE
Заменить "сэкономьте" на "скидка"

### DIFF
--- a/woocommerce-save-to-discount.css
+++ b/woocommerce-save-to-discount.css
@@ -1,0 +1,34 @@
+/* Замена "Сэкономьте" на "Скидка" в WooCommerce блоках */
+
+/* Скрываем оригинальный текст */
+.wc-block-components-sale-badge:lang(ru),
+.wc-block-components-product-badge:lang(ru) {
+    font-size: 0 !important;
+}
+
+/* Показываем новый текст */
+.wc-block-components-sale-badge:lang(ru):before,
+.wc-block-components-product-badge:lang(ru):before {
+    content: "Скидка ";
+    font-size: 14px;
+    font-weight: inherit;
+}
+
+/* Показываем сумму скидки обратно */
+.wc-block-components-sale-badge .wc-block-formatted-money-amount,
+.wc-block-components-product-badge .wc-block-formatted-money-amount {
+    font-size: 14px !important;
+}
+
+/* Альтернативный способ через data-attributes если они есть */
+.wc-block-components-sale-badge[data-text*="Сэкономьте"],
+.wc-block-components-product-badge[data-text*="Сэкономьте"] {
+    font-size: 0 !important;
+}
+
+.wc-block-components-sale-badge[data-text*="Сэкономьте"]:before,
+.wc-block-components-product-badge[data-text*="Сэкономьте"]:before {
+    content: "Скидка ";
+    font-size: 14px;
+    font-weight: inherit;
+}

--- a/woocommerce-translation-override.php
+++ b/woocommerce-translation-override.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Переопределение переводов WooCommerce
+ * Замена "Сэкономьте" на "Скидка"
+ */
+
+// Запретить прямой доступ
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Переопределение переводов WooCommerce
+ */
+function override_woocommerce_translations($translation, $text, $domain) {
+    // Если это WooCommerce или WooCommerce блоки
+    if (in_array($domain, ['woocommerce', 'woo-gutenberg-products-block', 'woocommerce-blocks'])) {
+        // Переводы для замены
+        $translations = array(
+            'Save' => 'Скидка',
+            'Сэкономьте' => 'Скидка',
+            'You save' => 'Скидка',
+            'Savings' => 'Скидка',
+        );
+        
+        // Проверяем есть ли замена для данного текста
+        if (isset($translations[$text])) {
+            return $translations[$text];
+        }
+    }
+    
+    return $translation;
+}
+
+// Добавляем фильтр для переопределения переводов
+add_filter('gettext', 'override_woocommerce_translations', 20, 3);
+add_filter('gettext_with_context', 'override_woocommerce_translations', 20, 3);
+
+/**
+ * Альтернативный способ через JavaScript для блоков
+ */
+function custom_woocommerce_blocks_script() {
+    ?>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Заменяем текст "Сэкономьте" на "Скидка" в блоках WooCommerce
+        function replaceText() {
+            const elements = document.querySelectorAll('.wc-block-components-sale-badge, .wc-block-components-product-badge');
+            elements.forEach(function(element) {
+                if (element.textContent.includes('Сэкономьте')) {
+                    element.innerHTML = element.innerHTML.replace(/Сэкономьте/g, 'Скидка');
+                }
+            });
+        }
+        
+        // Выполняем сразу
+        replaceText();
+        
+        // Наблюдаем за изменениями DOM для динамически загружаемых блоков
+        const observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(mutation) {
+                if (mutation.addedNodes.length > 0) {
+                    replaceText();
+                }
+            });
+        });
+        
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    });
+    </script>
+    <?php
+}
+
+// Добавляем скрипт в футер
+add_action('wp_footer', 'custom_woocommerce_blocks_script');

--- a/wp-content/languages/woocommerce-ru_RU.po
+++ b/wp-content/languages/woocommerce-ru_RU.po
@@ -1,0 +1,13 @@
+# WooCommerce Russian Translation Override
+msgid ""
+msgstr ""
+"Language: ru_RU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Save"
+msgstr "Скидка"
+
+msgid "Сэкономьте"
+msgstr "Скидка"


### PR DESCRIPTION
Translate 'Сэкономьте' to 'Скидка' for WooCommerce sale badges and related texts.

The original string 'Сэкономьте' was not found directly in the project files, suggesting it's dynamically generated by WooCommerce blocks or the theme. This PR provides three alternative methods (PO file, PHP filter, and CSS override) to ensure the desired translation is applied.